### PR TITLE
Fix the bug of using the same token for padding and eos

### DIFF
--- a/recognize.py
+++ b/recognize.py
@@ -36,7 +36,7 @@ def main():
         eos_token_id = tokenizer.convert_tokens_to_ids(
             ['<|endoftext|>', '<|im_end|>'])
     else:
-        tokenizer.pad_token = tokenizer.eos_token  # for LLaMa
+        tokenizer.pad_token = '<|finetune_right_pad_id|>'
         eos_token_id = tokenizer.convert_tokens_to_ids(
             ['<|end_of_text|>', '<|eot_id|>'])
     print('eos_token_id', eos_token_id)

--- a/train.py
+++ b/train.py
@@ -271,7 +271,8 @@ def main():
         model_max_length=training_args.model_max_length,
         padding_side="right",
     )
-    tokenizer.pad_token = tokenizer.eos_token  # for LLaMa
+    if 'llama' in model_args.llm_model_name_or_path:
+        tokenizer.pad_token = '<|finetune_right_pad_id|>'
 
     print("Loading data...")
     train_dataset = SpeechDataset(data_args.data_path,


### PR DESCRIPTION
Models trained with the original code cannot stop the generation in the decoding, leading to a high CER.

The original code uses eos_token as the pad_token. Then in the SpeechDataset iteration, tokens with the pad_token id are ignored in the loss calculation. Thus the model didn't learn how to generate EOS in the training. 

Therefore, it's a better practice to set padding_token to '<|finetune_right_pad_id|>'. This fix the issue and I was able to reproduce the ASR results using my updated codebase.

Please also refer to https://discuss.huggingface.co/t/how-to-set-the-pad-token-for-meta-llama-llama-3-models/103418/2